### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools", "wheel", "scikit-build", "cmake", "pip",
+  "setuptools", "wheel", "scikit-build", "cmake-odidev", "pip",
   "numpy==1.11.3; python_version=='3.5'",
   "numpy==1.13.3; python_version=='3.6'",
   "numpy==1.14.5; python_version=='3.7'",


### PR DESCRIPTION
cmake for aarch64 is broken. use cmake-odidev instead